### PR TITLE
Add function that outputs owner's name

### DIFF
--- a/src/MyStatsPackage.jl
+++ b/src/MyStatsPackage.jl
@@ -2,6 +2,10 @@ module MyStatsPackage
 
 include("statistic_functions.jl")
 
-export rse_sum, rse_mean, rse_std, rse_tstat
+export rse_sum, rse_mean, rse_std, rse_tstat, printOwner
+
+function printOwner()
+    println("Owner of the package is Dmitry Kabanov")
+end
 
 end # module


### PR DESCRIPTION
This PR adds the function `printOwner` that prints the name of the owner of this package.